### PR TITLE
chg: Ensure 100% forge coverage

### DIFF
--- a/src/ClaimToken.sol
+++ b/src/ClaimToken.sol
@@ -176,8 +176,11 @@ contract ClaimToken is IClaimToken, Ownable, ReentrancyGuard {
             bool isActivatedSigner = _isActivatedList[i];
 
             if (isActivatedSigner == _isActivatedSigner[signer]) {
-                require(!isActivatedSigner, SignerAlreadyActive(signer));
-                require(isActivatedSigner, SignerAlreadyDeactivated(signer));
+                if (isActivatedSigner) {
+                    revert SignerAlreadyActive(signer);
+                } else {
+                    revert SignerAlreadyDeactivated(signer);
+                }
             }
 
             if (isActivatedSigner) {


### PR DESCRIPTION
## Description

- `require` statements need to cover both "pass" and "halt" paths. Parallel `require` statements create four paths, making 100% coverage impossible. Use a single-path `revert` to achieve full coverage.

## Verification

```
$ forge build
$ forge coverage --report summary --match-path 'test/*.t.sol' --no-match-coverage '(script/|test/)' | sed '/^[^|]/d' | sed '/^$/d'
```

- Result

| File               | % Lines         | % Statements    | % Branches      | % Funcs         |
|--------------------|-----------------|-----------------|-----------------|-----------------|
| src/ClaimToken.sol | 100.00% (48/48) | 100.00% (64/64) | 100.00% (21/21) | 100.00% (12/12) |
| Total              | 100.00% (48/48) | 100.00% (64/64) | 100.00% (21/21) | 100.00% (12/12) |